### PR TITLE
sidekiq-postpone.gemspec: Remove exe configuration

### DIFF
--- a/sidekiq-postpone.gemspec
+++ b/sidekiq-postpone.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/marshall-lee/sidekiq-postpone"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "sidekiq", ">= 5", "< 8"


### PR DESCRIPTION
This gem exposes no executables.